### PR TITLE
Fix the script for phpmyadmin 3.5.1 and 3.4.10.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,34 @@ curl-phpmyadmin
 
 Export MySQL data from phpmyadmin using curl.
 
-	mysql-export.sh [-h|--help] [--stdout] [--tables=<table_name>,<table_name>] [--add-drop] [--apache-user=<apache_http_user>] [--apache-password=<apache_http_password>] [--phpmyadmin-user=<phpmyadmin_user>] [--phpmyadmin-password=<phpmyadmin_password>] [--database=<database>] [--host=<phpmyadmin_host>] [--use-keychain]
-		-h, --help: Print help
-		--stdout: Write SQL (gzipped) in stdout
-		--tables: Export only particular tables
-		--add-drop: add DROP TABLE IF EXISTS to every exporting table
-		--apache-user=<apache_http_user>: Apache HTTP autorization user
-		--apache-password=<apache_http_password>: Apache HTTP autorization password or keychain entry name if --use-keychain
-		--phpmyadmin-user=<phpmyadmin_user>: PhpMyAdmin user
-		--phpmyadmin-password=<phpmyadmin_password>: PhpMyAdmin password or keychain entry name if --use-keychain
-		--database=<database>: Database to be exported
-		--host=<phpmyadmin_host>: PhpMyAdmin host
-		--use-keychain: Use Mac OS X keychain to get passwords from. In that case --apache-password and --phpmyadmin-password will be used as account name for search in Mac Os X keychain. 
+	mysql-export.sh [-h|--help] [--stdout] [--tables=<table_name>,<table_name>,...] 
+	                            [--compression=none|gzip|bzip2|zip] [--add-drop] 
+	                            [--apache-user=<apache_http_user>] [--apache-password=<apache_http_password>] 
+	                            [--phpmyadmin-user=<phpmyadmin_user>] [--phpmyadmin-password=<phpmyadmin_password>] 
+	                            [--database=<database>] [--host=<phpmyadmin_host>] [--use-keychain] 
+	                            -- [curl_options]
+	        -h, --help: Print help
+	        --stdout: Write SQL (gzipped) in stdout
+	        --tables=<T1>,<T2>,..: Export only particular tables
+	        --compression: Turn compression off (none) or use gzip, bzip2 (default) or zip
+	        --add-drop: add DROP TABLE IF EXISTS to every exporting table
+	        --apache-user=<apache_http_user>: Apache HTTP autorization user
+	        --apache-password=<apache_http_password>: Apache HTTP autorization password 
+	        --phpmyadmin-user=<phpmyadmin_user>: PhpMyAdmin user *
+	        --phpmyadmin-password=<phpmyadmin_password>: PhpMyAdmin password *
+	        --database=<database>: Database to be exported *
+	        --host=<phpmyadmin_host>: PhpMyAdmin host *
+	        --use-keychain: Use Mac OS X keychain to get passwords from. 
+	          In that case --apache-password and --phpmyadmin-password will be used 
+	          as account name for search in Mac Os X keychain. 
+	 
+	        * You need to set at least those parameters on the command line or in the script
+	 
+	        --  [curl_options] Options may be passed to every curl command (e.g. http_proxy)
+ 
 
  Common uses:
 
 	mysql-export.sh --tables=hotel_content_provider --add-drop --database=hs --stdout --use-keychain --apache-user=betatester --phpmyadmin-user=hs --apache-password=www.example.com\ \(me\) --phpmyadmin-password=phpmyadmin.example.com --host=https://www.example.com/phpmyadmin | gunzip | mysql -u root -p testtable
-exports and imports on the fly in local db
+
+This exports and imports on the fly into local db.

--- a/mysql-export.sh
+++ b/mysql-export.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 #set -x
 
@@ -11,118 +11,188 @@
 # Clean up and add parameter handling by Artem Grebenkin
 # <speechkey@gmail.com> http://www.irepository.net
 #
-# This saves dumps of your Database using CURL and connecting to
+# Script now consistenly in bash-style (was broken on my system using /bin/sh)
+# Adapted post_params to comply with current phpmyadmin installations
+# Added functionality: all compression offered by phpmyadmin, curl option passing
+# 2013 Tobias Küchel <devel@zukuul.de> 
+#
+# Optional: This saves dumps of your Database using CURL and connecting to
 # phpMyAdmin (via HTTPS), keeping the 10 latest backups by default
 #
-# Tested on phpMyAdmin 3.4.5
+# Tested on phpMyAdmin 3.5.1 and 3.4.10.1
 #
 # For those interested in debugging/adapting this script, the firefox
 # add-on LiveHttpHeaders is a very interesting extension to debug HTTP
 # transactions and guess what's needed to develop such a CURL-based
 # script.
 #
-# Arguments: mysql-export.sh [-h|--help] [--stdout] [--tables=<table_name>,<table_name>] [--add-drop] [--apache-user=<apache_http_user>] [--apache-password=<apache_http_password>] [--phpmyadmin-user=<phpmyadmin_user>] [--phpmyadmin-password=<phpmyadmin_password>] [--database=<database>] [--host=<phpmyadmin_host>] [--use-keychain]
-#	-h, --help: Print help
-# 	--stdout: Write SQL (gzipped) in stdout
-#	--tables: Export only particular tables
-#	--add-drop: add DROP TABLE IF EXISTS to every exporting table
-#	--apache-user=<apache_http_user>: Apache HTTP autorization user
-#	--apache-password=<apache_http_password>: Apache HTTP autorization password or keychain entry name if --use-keychain
-#	--phpmyadmin-user=<phpmyadmin_user>: PhpMyAdmin user
-#	--phpmyadmin-password=<phpmyadmin_password>: PhpMyAdmin password or keychain entry name if --use-keychain
-#	--database=<database>: Database to be exported
-#	--host=<phpmyadmin_host>: PhpMyAdmin host
-#	--use-keychain: Use Mac OS X keychain to get passwords from. In that case --apache-password and --phpmyadmin-password will be used as account name for search in Mac Os X keychain. 
-#
-# Common uses: mysql-export.sh --tables=hotel_content_provider --add-drop --database=hs --stdout --use-keychain --apache-user=betatester --phpmyadmin-user=hs --apache-password=www.example.com\ \(me\) --phpmyadmin-password=phpmyadmin.example.com --host=https://www.example.com/phpmyadmin | gunzip | mysql -u root -p testtable
-#	       exports and imports on the fly in local db
-
+# Arguments: mysql-export.sh [-h|--help] [--stdout] [--tables=<table_name>,<table_name>,...] 
+#                            [--compression=none|gzip|bzip2|zip] [--add-drop] 
+#                            [--apache-user=<apache_http_user>] [--apache-password=<apache_http_password>] 
+#                            [--phpmyadmin-user=<phpmyadmin_user>] [--phpmyadmin-password=<phpmyadmin_password>] 
+#                            [--database=<database>] [--host=<phpmyadmin_host>] [--use-keychain] 
+#                            -- [curl_options]
+#        -h, --help: Print help
+#        --stdout: Write SQL (gzipped) in stdout
+#        --tables=<T1>,<T2>,..: Export only particular tables
+#        --compression: Turn compression off (none) or use gzip, bzip2 (default) or zip
+#        --add-drop: add DROP TABLE IF EXISTS to every exporting table
+#        --apache-user=<apache_http_user>: Apache HTTP autorization user
+#        --apache-password=<apache_http_password>: Apache HTTP autorization password 
+#        --phpmyadmin-user=<phpmyadmin_user>: PhpMyAdmin user *
+#        --phpmyadmin-password=<phpmyadmin_password>: PhpMyAdmin password *
+#        --database=<database>: Database to be exported *
+#        --host=<phpmyadmin_host>: PhpMyAdmin host *
+#        --use-keychain: Use Mac OS X keychain to get passwords from. 
+#          In that case --apache-password and --phpmyadmin-password will be used 
+#          as account name for search in Mac Os X keychain. 
+# 
+#        * You need to set at least those parameters on the command line or in the script
+# 
+#        --  [curl_options] Options may be passed to every curl command (e.g. http_proxy)
+# 
+#  Common uses: mysql-export.sh --tables=hotel_content_provider --add-drop --database=hs --stdout --use-keychain --apache-user=betatester --phpmyadmin-user=hs --apache-password=www.example.com\ \(me\) --phpmyadmin-password=phpmyadmin.example.com --host=https://www.example.com/phpmyadmin | gunzip | mysql -u root -p testtable
+# 
+# 	This exports and imports on the fly into local db
+# 
 # Please adapt these values :
 
-APACHE_USER=0
-APACHE_PASSWD=0
-
-PHPMYADMIN_USER=0
-PHPMYADMIN_PASSWD=0
-
-REMOTE_HOST=0
-DATABASE=0
-COMPRESSION=on
-ADD_DROP=1
-TMP_FOLDER="/tmp"
+MKTEMP=mktemp # 'mktemp' or 'tempfile'
+TMP_FOLDER=/tmp
+COMPRESSION=bzip2
 USE_KEYCHAIN=0
+DEBUG=0
 
+## following values will be overwritten by command line arguments
+STDOUT=
+DB_TABLES=
+ADD_DROP=0
+APACHE_USER=
+APACHE_PASSWD=
+PHPMYADMIN_USER=
+PHPMYADMIN_PASSWD=
+DATABASE=
+REMOTE_HOST=
 # End of customisations
 
-stdin=0
-export_tables=0
-add_drop=0
 
-for arg in $@
-do
-	if [ $arg == '-h' ] || [ $arg == '--help' ]
-	then
+## debugging function
+function decho {
+    [ $DEBUG -eq 1 ] &&	echo $@
+}
+
+function usage
+{
 		cat << EOF
-Arguments: mysql-export.sh [-h|--help] [--stdout] [--tables=<table_name>,<table_name>] [--add-drop] [--apache-user=<apache_http_user>] [--apache-password=<apache_http_password>] [--phpmyadmin-user=<phpmyadmin_user>] [--phpmyadmin-password=<phpmyadmin_password>] [--database=<database>] [--host=<phpmyadmin_host>] [--use-keychain]
+Arguments: mysql-export.sh [-h|--help] [--stdout] [--tables=<table_name>,<table_name>,...] 
+                           [--compression=none|gzip|bzip2|zip] [--add-drop] 
+                           [--apache-user=<apache_http_user>] [--apache-password=<apache_http_password>] 
+                           [--phpmyadmin-user=<phpmyadmin_user>] [--phpmyadmin-password=<phpmyadmin_password>] 
+                           [--database=<database>] [--host=<phpmyadmin_host>] [--use-keychain] 
+                           -- [curl_options]
        -h, --help: Print help
        --stdout: Write SQL (gzipped) in stdout
-       --tables: Export only particular tables
+       --tables=<T1>,<T2>,..: Export only particular tables
+       --compression: Turn compression off (none) or use gzip, bzip2 (default) or zip
        --add-drop: add DROP TABLE IF EXISTS to every exporting table
        --apache-user=<apache_http_user>: Apache HTTP autorization user
-       --apache-password=<apache_http_password>: Apache HTTP autorization password or keychain entry name if --use-keychain
-       --phpmyadmin-user=<phpmyadmin_user>: PhpMyAdmin user
-       --phpmyadmin-password=<phpmyadmin_password>: PhpMyAdmin password or keychain entry name if --use-keychain
-       --database=<database>: Database to be exported
-       --host=<phpmyadmin_host>: PhpMyAdmin host
-       --use-keychain: Use Mac OS X keychain to get passwords from. In that case --apache-password and --phpmyadmin-password will be used as account name for search in Mac Os X keychain. 
+       --apache-password=<apache_http_password>: Apache HTTP autorization password 
+       --phpmyadmin-user=<phpmyadmin_user>: PhpMyAdmin user *
+       --phpmyadmin-password=<phpmyadmin_password>: PhpMyAdmin password *
+       --database=<database>: Database to be exported *
+       --host=<phpmyadmin_host>: PhpMyAdmin host *
+       --use-keychain: Use Mac OS X keychain to get passwords from. 
+         In that case --apache-password and --phpmyadmin-password will be used 
+         as account name for search in Mac Os X keychain. 
+
+       * You need to set at least those parameters on the command line or in the script
+
+       --  [curl_options] Options may be passed to every curl command (e.g. http_proxy)
 
  Common uses: mysql-export.sh --tables=hotel_content_provider --add-drop --database=hs --stdout --use-keychain --apache-user=betatester --phpmyadmin-user=hs --apache-password=www.example.com\ \(me\) --phpmyadmin-password=phpmyadmin.example.com --host=https://www.example.com/phpmyadmin | gunzip | mysql -u root -p testtable
-	exports and imports on the fly in local db
-EOF
-exit 0
 
-	elif [ $arg == '--stdout' ]
+	This exports and imports on the fly into local db
+EOF
+}
+
+curloptions=0
+curlopts=""
+for arg in $@
+do
+        if [ $arg == "--" ]
 	then
-		stdin=1
-	elif [[ $arg =~ --tables ]]
+	    curloptions=1
+	elif [ $curloptions -eq 1 ]
 	then
-		export_tables=1
-		db_tables=$arg
-	elif [ $arg == '--compression=off' ]
+	    curlopts+="$arg "
+        elif [ $arg == '--stdout' ]
 	then
-		COMPRESSION=off
+		STDOUT=1
+	elif [[ $arg =~ '--tables' ]]
+	then
+		DB_TABLES=$arg
+	elif [[ $arg =~ '--compression' ]]
+	then
+		COMPRESSION=${arg:14}
 	elif [ $arg == '--add-drop' ]
 	then
-		add_drop=1
-	elif [[ $arg =~ --apache-user ]] && [ $APACHE_USER -eq 0 ]
+		ADD_DROP=1
+	elif [[ $arg =~ '--apache-user' ]] 
 	then
 		APACHE_USER=${arg:14}
-	elif [[ $arg =~ --apache-password ]] && [ $APACHE_PASSWD -eq 0 ]
+	elif [[ $arg =~ '--apache-password' ]] 
 	then
 		APACHE_PASSWD=${arg:18}
-	elif [[ $arg =~ --phpmyadmin-user ]] && [ $PHPMYADMIN_USER -eq 0 ]
+	elif [[ $arg =~ '--phpmyadmin-user' ]] 
 	then
 		PHPMYADMIN_USER=${arg:18}
-	elif [[ $arg =~ --phpmyadmin-password ]] && [ $PHPMYADMIN_PASSWD -eq 0 ]
+	elif [[ $arg =~ '--phpmyadmin-password' ]] 
 	then
 		PHPMYADMIN_PASSWD=${arg:22}
-	elif [[ $arg =~ --database ]] && [ $DATABASE -eq 0 ]
+	elif [[ $arg =~ '--database' ]] 
 	then
 		DATABASE=${arg:11}
-	elif [[ $arg =~ --host ]] && [ $REMOTE_HOST -eq 0 ]
+	elif [[ $arg =~ '--host' ]] 
 	then
 		REMOTE_HOST=${arg:7}
-	elif [[ $arg == '--use-keychain' ]]
+	elif [ $arg == '--use-keychain' ]
 	then
 		USE_KEYCHAIN=1
+	else
+	    usage
+	    exit 0	    
 	fi
 done
+curlopts+="-s -k -L"
+decho "Curl options: $curlopts"
 
+# is APACHE auth really necessary?
+#[ -z "$APACHE_USER" -o -z "$APACHE_PASSWD" ] && usage && exit 1
+#if [ -z "$PHPMYADMIN_USER" -o -z "$PHPMYADMIN_PASSWD" ];
+if [ -z "$DATABASE" -o -z "$REMOTE_HOST" ];
+then 
+    usage
+    exit 1
+fi
+
+## not tested (01.03.13)
 if [ $USE_KEYCHAIN -eq 1 ]
 then
 	APACHE_PASSWD=`security 2>&1 >/dev/null find-internet-password -gs $APACHE_PASSWD | sed -e 's/password: "\(.*\)"/\1/g'`
 	PHPMYADMIN_PASSWD=`security 2>&1 >/dev/null find-internet-password -g -l $PHPMYADMIN_PASSWD | sed -e 's/password: "\(.*\)"/\1/g'`
 fi
+
+## which mktemp to use
+mkdir -p $TMP_FOLDER || exit 1
+if [ "$MKTEMP" == "mktemp" ]; then
+    result=$(`which mktemp` "$TMP_FOLDER/phpmyadmin_export.XXXXXX.tmp")
+    decho TEMP: $result
+fi
+if [ "MKTEMP" == "tempfile" ]; then
+    result=$(`which tempfile` -d "$TMP_FOLDER")
+    decho TEMP: $result
+fi
+
 
 ###############################################################
 #
@@ -130,166 +200,163 @@ fi
 #
 ###############################################################
 
-MKTEMP=/bin/tempfile
-if [ ! -x $MKTEMP ]; then
-    MKTEMP=/usr/bin/mktemp
-fi
-
-result=$($MKTEMP "$TMP_FOLDER/phpmyadmin_export.$RANDOM.tmp")
-
 apache_auth_params="--anyauth -u$APACHE_USER:$APACHE_PASSWD"
 
-curl -s -k -D $TMP_FOLDER/curl.headers -L -c $TMP_FOLDER/cookies.txt $apache_auth_params $REMOTE_HOST/index.php > $result
-    token=$(grep link $result | grep 'phpmyadmin.css.php' | grep token | sed "s/^.*token=//" | sed "s/&.*//" )
+curl $curlopts -D $TMP_FOLDER/curl.headers -c $TMP_FOLDER/cookies.txt $apache_auth_params $REMOTE_HOST/index.php > $result
+#    token=$(grep 'token\ =' $result | sed "s/.*token\ =\ '//;s/';$//" )
 
+    token=$(grep link $result | grep 'phpmyadmin.css.php' | grep token | sed "s/^.*token=//" | sed "s/&.*//" )
     cookie=$(cat $TMP_FOLDER/cookies.txt | cut  -f 6-7 | grep phpMyAdmin | cut -f 2)
 
-    entry_params="-d \"phpMyAdmin=$cookie&phpMyAdmin=$cookie&pma_username=$PHPMYADMIN_USER&pma_password=$PHPMYADMIN_PASSWD&server=1&phpMyAdmin=$cookie&lang=en-utf-8&convcharset=utf-8&collation_connection=utf8_general_ci&token=$token&input_go=Go\""
-
-
-curl -s -S -k -L  -D $TMP_FOLDER/curl.headers -b $TMP_FOLDER/cookies.txt -c $TMP_FOLDER/cookies.txt $apache_auth_params $entry_params $REMOTE_HOST/index.php > $result
-
-if [ $? -ne 0 ]
-then
-     echo "Curl Error on : curl $entry_params -s -k -D $TMP_FOLDER/curl.headers -L -c $TMP_FOLDER/cookies.txt $REMOTE_HOST/index.php. Check contents of $result" >&2
-     exit 1
+entry_params="-d \"phpMyAdmin=$cookie&pma_username=$PHPMYADMIN_USER&pma_password=$PHPMYADMIN_PASSWD&server=1&lang=en-utf-8&convcharset=utf-8&collation_connection=utf8_general_ci&token=$token&input_go=Go\""
+decho Apache login: $apache_auth_params
+decho PhpMyadmin login: $entry_params
+decho Token: $token
+decho Cookie: $cookie
+## Try to log in with PhpMyAdmin username and password showing errors if it fails
+curl $curlopts -S -D $TMP_FOLDER/curl.headers -b $TMP_FOLDER/cookies.txt -c $TMP_FOLDER/cookies.txt $apache_auth_params $entry_params $REMOTE_HOST/index.php > $result
+## did it fail?
+if [ $? -ne 0 ]; then
+    echo "Curl Error on : curl $curlopts -S -D $TMP_FOLDER/curl.headers -b $TMP_FOLDER/cookies.txt -c $TMP_FOLDER/cookies.txt $apache_auth_params $entry_params $REMOTE_HOST/index.php > $result" >&2
+    exit 1
 fi
+## Was the http-request unsuccessful?
 grep -q "HTTP/1.1 200 OK" $TMP_FOLDER/curl.headers
-if [ $? -ne 0 ]
-then
-         echo -n "Error : couldn't login to phpMyadmin on $REMOTE_HOST/index.php" >&2
-         grep "HTTP/1.1 " $TMP_FOLDER/curl.headers >&2
-         exit 1
+if [ $? -ne 0 ]; then
+    echo -n "Error : couldn't login to phpMyadmin on $REMOTE_HOST/index.php" >&2
+    grep "HTTP/1.1 " $TMP_FOLDER/curl.headers >&2
+    exit 1
 fi
 
-md5cookie=$token
 
-post_params="token=$md5cookie"
-post_params="$post_params&export_type=server"
-post_params="$post_params&export_method=quick"
-post_params="$post_params&quick_or_custom=custom"
-post_params="$post_params&db_select[]=$DATABASE"
-post_params="$post_params&output_format=sendit"
 
-post_params="$post_params&what=sql"
-post_params="$post_params&codegen_structure_or_data=data"
-# post_params="$post_params&codegen_format=0"
-# post_params="$post_params&csv_separator=%3B"
-# post_params="$post_params&csv_enclosed=%22"
-# post_params="$post_params&csv_escaped=%5C"
-# post_params="$post_params&csv_terminated=AUTO"
-# post_params="$post_params&csv_null=NULL"
-post_params="$post_params&csv_structure_or_data=data"
-# post_params="$post_params&excel_null=NULL"
-# post_params="$post_params&excel_edition=win"
-post_params="$post_params&excel_structure_or_data=data"
-# post_params="$post_params&htmlword_structure=something"
-post_params="$post_params&htmlword_structure_or_data=structure_and_data"
-# post_params="$post_params&htmlword_null=NULL"
-# post_params="$post_params&latex_caption=something"
-# post_params="$post_params&latex_structure=something"
-# post_params="$post_params&latex_structure_caption=Structure+of+table+__TABLE__"
-# post_params="$post_params&latex_structure_continued_caption=Structure+of+table+__TABLE__+%28continued%29"
-# post_params="$post_params&latex_structure_label=tab%3A__TABLE__-structure"
-# post_params="$post_params&latex_comments=something"
-post_params="$post_params&latex_data=something"
-# post_params="$post_params&latex_columns=something"
-# post_params="$post_params&latex_data_caption=Content+of+table+__TABLE__"
-# post_params="$post_params&latex_data_continued_caption=Content+of+table+__TABLE__+%28continued%29"
-# post_params="$post_params&latex_data_label=tab%3A__TABLE__-data"
-# post_params="$post_params&latex_null=%5Ctextit%7BNULL%7D"
-post_params="$post_params&mediawiki_structure_or_data=data"
-# post_params="$post_params&ods_null=NULL"
-post_params="$post_params&ods_structure_or_data=data"
-# post_params="$post_params&odt_structure=something"
-# post_params="$post_params&odt_comments=something"
-post_params="$post_params&odt_data=something"
-# post_params="$post_params&odt_columns=something"
-# post_params="$post_params&odt_null=NULL"
-# post_params="$post_params&pdf_report_title="
-post_params="$post_params&pdf_data=1"
-post_params="$post_params&php_array_structure_or_data=data"
-post_params="$post_params&sql_header_comment="
-post_params="$post_params&sql_include_comments=something"
-post_params="$post_params&sql_compatibility=NONE"
-post_params="$post_params&sql_structure_or_data=structure_and_data"
-post_params="$post_params&sql_if_not_exists=something"
-post_params="$post_params&sql_auto_increment=something"
-post_params="$post_params&sql_backquotes=something"
-post_params="$post_params&sql_data=something"
-post_params="$post_params&sql_columns=something"
-post_params="$post_params&sql_extended=something"
-post_params="$post_params&sql_max_query_size=50000"
-post_params="$post_params&sql_hex_for_blob=something"
-post_params="$post_params&sql_type=INSERT"
-# post_params="$post_params&texytext_structure=something"
-post_params="$post_params&texytext_data=something"
-# post_params="$post_params&texytext_null=NULL"
-# post_params="$post_params&xls_null=NULL"
-post_params="$post_params&xls_structure_or_data=data"
-# post_params="$post_params&xlsx_null=NULL"
-post_params="$post_params&xlsx_structure_or_data=data"
-post_params="$post_params&yaml_structure_or_data=data"
-post_params="$post_params&asfile=sendit"
-post_params="$post_params&filename_template=__SERVER__"
-post_params="$post_params&remember_template=on"
-post_params="$post_params&charset_of_file=utf-8"
+## prepare the post-parameters
+post_params="token=${token}"
+## later: post_params+="&export_type=server"
+post_params+="&export_method=quick"
+post_params+="&quick_or_custom=custom"
+## later: post_params+="&db_select%5B%5D=$DATABASE"
+post_params+="&output_format=sendit"
+## later: post_params+="&filename_template=%40SERVER%40" 
+post_params+="&remember_template=on"
+post_params+="&charset_of_file=utf-8"
+## later: post_params+="&compression=none"
+post_params+="&what=sql"
+post_params+="&codegen_structure_or_data=data"
+post_params+="&codegen_format=0"
+post_params+="&csv_separator=%2C"
+post_params+="&csv_enclosed=%22"
+post_params+="&csv_escaped=%22"
+post_params+="&csv_terminated=AUTO"
+post_params+="&csv_null=NULL"
+post_params+="&csv_structure_or_data=data"
+post_params+="&excel_null=NULL"
+post_params+="&excel_edition=win"
+post_params+="&excel_structure_or_data=data"
+post_params+="&htmlword_structure_or_data=structure_and_data"
+post_params+="&htmlword_null=NULL"
+post_params+="&json_structure_or_data=data"
+post_params+="&latex_caption=something"
+post_params+="&latex_structure_or_data=structure_and_data"
+post_params+="&latex_structure_caption=Structure+of+table+%40TABLE%40"
+post_params+="&latex_structure_continued_caption=Structure+of+table+%40TABLE%40+%28continued%29"
+post_params+="&latex_structure_label=tab%3A%40TABLE%40-structure"
+post_params+="&latex_comments=something"
+post_params+="&latex_columns=something"
+post_params+="&latex_data_caption=Content+of+table+%40TABLE%40"
+post_params+="&latex_data_continued_caption=Content+of+table+%40TABLE%40+%28continued%29"
+post_params+="&latex_data_label=tab%3A%40TABLE%40-data"
+post_params+="&latex_null=%5Ctextit%7BNULL%7D"
+post_params+="&mediawiki_structure_or_data=data"
+post_params+="&ods_null=NULL"
+post_params+="&ods_structure_or_data=data"
+post_params+="&odt_structure_or_data=structure_and_data"
+post_params+="&odt_comments=something"
+post_params+="&odt_columns=something"
+post_params+="&odt_null=NULL"
+post_params+="&pdf_report_title="
+post_params+="&pdf_structure_or_data=data"
+post_params+="&php_array_structure_or_data=data"
+post_params+="&sql_include_comments=something"
+post_params+="&sql_header_comment="
+post_params+="&sql_compatibility=NONE"
+post_params+="&sql_structure_or_data=structure_and_data"
+post_params+="&sql_procedure_function=something"
+post_params+="&sql_create_table_statements=something"
+post_params+="&sql_if_not_exists=something"
+post_params+="&sql_auto_increment=something"
+post_params+="&sql_backquotes=something"
+post_params+="&sql_type=INSERT"
+post_params+="&sql_insert_syntax=both"
+post_params+="&sql_max_query_size=50000"
+post_params+="&sql_hex_for_blob=something"
+post_params+="&sql_utc_time=something"
+post_params+="&texytext_structure_or_data=structure_and_data"
+post_params+="&texytext_null=NULL"
+post_params+="&yaml_structure_or_data=data"
 
-if [ $add_drop -eq 1 ]
-then
-	post_params="$post_params&sql_drop_table=something"
-	post_params="$post_params&sql_structure=data"
-fi
+if [ $ADD_DROP -eq 1 ];  then
+    post_params+="&sql_drop_table=something"
+fi    
 
-if [ "$COMPRESSION" = "on" ]
-then
-    post_params="$post_params&compression=gzip"
+target="$(echo $REMOTE_HOST | sed 's@^http[s]://@@;s@/.*@@')_${DATABASE}_$(date  +%Y%m%d%H%M).sql"
+#target="$(echo $REMOTE_HOST | sed 's@^http[s]://@@;s@/.*@@')_${DATABASE}.sql"
+
+post_params+="&compression=$COMPRESSION"
+case $COMPRESSION in 
+    gzip)
+	target+=".gz" ;;
+    bzip2)
+	target+=".bz2" ;;	    
+    zip)
+	target+=".zip" ;;	    
+    none)
+	;;
+    *)
+	target+="err.compression" ;;	    	    
+esac
+
+decho Database: $DATABASE
+if [  -n "$DB_TABLES" ] ; then
+	DB_TABLES=${DB_TABLES/=/table_select%5B%5D=}
+	DB_TABLES=${DB_TABLES//,/&table_select%5B%5D=}
+	DB_TABLES=${DB_TABLES:8}
+	decho Tables: $DB_TABLES
+	
+	post_params+="&db=$DATABASE"
+	post_params+="&export_type=database"
+	post_params+="&$DB_TABLES"
+	post_params+="&filename_template=%40DATABASE%40"
+
+	post_params+="&xml_structure_or_data=data"
+	post_params+="&xml_export_functions=something"
+	post_params+="&xml_export_procedures=something"
+	post_params+="&xml_export_tables=something"
+	post_params+="&xml_export_triggers=something"
+	post_params+="&xml_export_views=something"
+	post_params+="&xml_export_contents=something"
 else
-    post_params="$post_params&compression=none"
-fi
-#&sql_hex_for_binary=something
-
-#2.7.0-pl2
-#post_params="$post_params&sql_structure=structure"
-#post_params="$post_params&sql_auto_increment=1"
-#post_params="$post_params&sql_compat=NONE"
-#post_params="$post_params&use_backquotes=1"
-#post_params="$post_params&sql_data=data"
-#post_params="$post_params&hexforbinary=yes"
-#post_params="$post_params&sql_type=insert"
-#post_params="$post_params&lang=fr-utf-8&server=1&collation_connection=utf8_general_ci&buttonGo=Exécuter"
-
-if [ $export_tables -eq 1 ]
-then
-	db_tables=${db_tables/=/table_select[]=}
-	db_tables=${db_tables//,/&table_select[]=}
-	db_tables=${db_tables:8}
-	
-	post_params="$post_params&db=$DATABASE&export_type=database&$db_tables&filename_template=__DB__"
-	
+	post_params+="&export_type=server"
+	post_params+="&db_select%5B%5D=$DATABASE"
+	post_params+="&filename_template=%40SERVER%40" 
 fi
 
-if [ $stdin -eq 1 ]
-then
-	curl -g -s -S -k -D $TMP_FOLDER/curl.headers -L -b $TMP_FOLDER/cookies.txt $apache_auth_params -d "$post_params" $REMOTE_HOST/export.php
+## the important curl command, either output to stdout additionally
+if [ -n "$STDOUT" ] ; then
+decho "	Exportcommand: curl $curlopts -g -S -D $TMP_FOLDER/curl.headers -b $TMP_FOLDER/cookies.txt $apache_auth_params -d "$post_params" $REMOTE_HOST/export.php"
+	curl $curlopts -g -S -D $TMP_FOLDER/curl.headers -b $TMP_FOLDER/cookies.txt $apache_auth_params -d "$post_params" $REMOTE_HOST/export.php
 else
-	curl -g -s -S -O -k -D $TMP_FOLDER/curl.headers -L -b $TMP_FOLDER/cookies.txt $apache_auth_params -d "$post_params" $REMOTE_HOST/export.php
-	
+decho " Exportcommand: curl $curlopts -g -S -O -D $TMP_FOLDER/curl.headers -b $TMP_FOLDER/cookies.txt $apache_auth_params -d "$post_params" $REMOTE_HOST/export.php"	
+	curl $curlopts -g -S -O -D $TMP_FOLDER/curl.headers -b $TMP_FOLDER/cookies.txt $apache_auth_params -d "$post_params" $REMOTE_HOST/export.php
+
+        ##  check if there was an attachement
 	grep -q "Content-Disposition: attachment" $TMP_FOLDER/curl.headers
-	if [ $? -eq 0 ]
-	then
-		filename="$(echo $remote_host | sed 's/\./-/g')_${database}_$(date  +%Y%m%d%H%M).sql"
-
-		if [ "$COMPRESSION" = "on" ]
-    		then
-        		filename="$filename.gz"
-		        mv export.php backup_mysql_$filename
-		        echo "Saved: backup_mysql_$filename"
-		else
-		        mv export.php backup_mysql_$filename
-		        gzip backup_mysql_$filename
-		        echo "Saved: backup_mysql_$filename.gz"
-		fi
+	if [ $? -eq 0 ] ; then
+	    mv export.php $target
+	    echo "Saved: $target"
+	else
+	    echo "Error: No attachment. Something went wrong. See export.php"
+	    exit 1
 	fi
 fi
 


### PR DESCRIPTION
Hi.
- Script now consistenly in bash-style (was broken on my system using /bin/sh)
- Adapted post_params to comply with current phpmyadmin installations
- Added functionality: all compression offered by phpmyadmin, curl option passing
- Added debugging feature to show the full curl command on DEBUG=1

I know, it is a big pull-request, sorry.
